### PR TITLE
MIME-type validering - Uploaded file extension samme som filename extension

### DIFF
--- a/src/Altinn.FileAnalyzers/MimeType/MimeTypeValidator.cs
+++ b/src/Altinn.FileAnalyzers/MimeType/MimeTypeValidator.cs
@@ -6,7 +6,7 @@ using Altinn.Platform.Storage.Interface.Models;
 namespace Altinn.FileAnalyzers.MimeType;
 
 /// <summary>
-/// Validates that the file is of the allowed content type
+/// Validates that the file is of the allowed content and uploaded file extension is the same as filename extension.
 /// </summary>
 public class MimeTypeValidator : IFileValidator
 {
@@ -16,7 +16,7 @@ public class MimeTypeValidator : IFileValidator
     public string Id { get; private set; } = "mimeTypeValidator";
 
     /// <summary>
-    /// Validates that the file is of the allowed content type.
+    /// Validates that the file is of the allowed content type and uploaded file extension is the same as filename extension.
     /// </summary>
 #pragma warning disable CS1998 // Async method lacks 'await' operators and will run synchronously. Suppressed because of the interface.
     public async Task<(bool Success, IEnumerable<ValidationIssue> Errors)> Validate(DataType dataType, IEnumerable<FileAnalysisResult> fileAnalysisResults)
@@ -25,6 +25,27 @@ public class MimeTypeValidator : IFileValidator
         List<ValidationIssue> errors = new();
 
         var fileMimeTypeResult = fileAnalysisResults.FirstOrDefault(x => x.MimeType != null);
+        if (fileMimeTypeResult == null) return (true, errors);
+
+        // Verify that uploaded file extension is the same as filename extension
+
+        foreach (var fileExtension in fileMimeTypeResult.Extensions)
+        {
+            if (fileMimeTypeResult.Filename != null && !fileMimeTypeResult.Filename.EndsWith(fileExtension))
+            {
+                ValidationIssue error = new()
+                {
+                    Source = "File",
+                    Code = "Uploaded file extension is not the same as filename extension", // TODO - Add correct code
+                    Severity = ValidationIssueSeverity.Error,
+                    Description = $"The {fileMimeTypeResult.Filename} filename does not appear to have the same extension as uploaded file. File extension on uploaded file is .{fileExtension}"
+                };
+
+                errors.Add(error);
+
+                return (false, errors);
+            }
+        }
 
         // Verify that file mime type is an allowed content-type
         if (!dataType.AllowedContentTypes.Contains(fileMimeTypeResult?.MimeType, StringComparer.InvariantCultureIgnoreCase) && !dataType.AllowedContentTypes.Contains("application/octet-stream"))


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Vi har en dataType "Gjennomfoeringsplan" som har "allowedContentTypes": [ "application/pdf", "application/xml" ]
Dersom vi laster opp en xml-fil og setter headers med Content-type: "application/pdf" og Content-Disposition: "attachment; filename={{dataType}}.pdf", vil filen bli lastet opp uten valideringsfeil. På instansen vil det nå ligge et dataElement som har "filename" og "contentType" som tilsier at det er en PDF, men når man ser på innholdet så er det en XML.
Vi ønsker å validere innholdet i filen dersom det er en xml, og vil gjerne stole på at contentType og extension på filename faktisk stemmer overens med innholdet, så man kan sjekke basert på det.
MimeTypeValidator bør derfor sjekke file extension på opplastet fil, mot filename fra header. 

## Related Issue(s)
- https://github.com/Altinn/app-lib-dotnet/issues/615

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
